### PR TITLE
Avoid error in Private mode (and older browsers)

### DIFF
--- a/app.js
+++ b/app.js
@@ -204,7 +204,9 @@ function onKeywordsChanged(keywords) {
 
 (async () => {
   // Register service worker for PWA
-  navigator.serviceWorker.register('sw.js');
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js');
+  }
   // Render cached news
   save();
   renderSettings();


### PR DESCRIPTION
According to MDN (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serviceWorker):

> The feature (`navigator.serviceWorker`) may not be available in private mode.

This change helps providing progressive enhancement for users in private mode and to older browsers that may not support the service worker functionality.